### PR TITLE
Create mutex-protected RPC count

### DIFF
--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -5,7 +5,11 @@
 
 #include "ClientHandler.h"
 #include <regex>
-
+#include "pthread.h"
+#include <unistd.h>
+#include <sys/socket.h>
+#include "Calculator.h"
+#include <iostream>
 using namespace std;
 
 /**
@@ -33,7 +37,7 @@ ClientHandler::~ClientHandler() {};
 /**
  * ProcessRPC will examine buffer and will essentially control
  */
-bool ClientHandler::ProcessRPC()
+bool ClientHandler::ProcessRPC(pthread_mutex_t *lock, int *rpcCounter)
 {
     char buffer[1024] = { 0 };
     std::vector<std::string> arrayTokens;
@@ -50,7 +54,10 @@ bool ClientHandler::ProcessRPC()
         printf("Waiting for client to send buffer\n");
 
         valread = read(this->m_socket, buffer, sizeof(buffer));
-
+	pthread_mutex_lock(lock);
+	*rpcCounter += 1;
+	cout << "Total number of RPCs is now" << *rpcCounter << endl;
+	pthread_mutex_unlock(lock);
         printf("Received buffer from client: %s\n", buffer);
 
         if (valread <= 0)

--- a/server/ClientHandler.h
+++ b/server/ClientHandler.h
@@ -6,7 +6,13 @@
 #ifndef CPSC5042CLIENTSERVER_CLIENTHANDLER_H
 #define CPSC5042CLIENTSERVER_CLIENTHANDLER_H
 
-#include "RPCServer.h"
+//#include "RPCServer.h"
+#include <unordered_map>
+#include <string>
+#include <vector>
+#include "pthread.h"
+
+using namespace std;
 
 class ClientHandler{
 public:
@@ -19,7 +25,7 @@ public:
     *
     * @return Always TRUE
     */
-    bool ProcessRPC();
+    bool ProcessRPC(pthread_mutex_t *lock, int *rpcCounter);
 
 private:
     int m_socket; //socket number


### PR DESCRIPTION
Commented out include of RPCServer.h from ClientHandler.cpp. I feel like RPCServer uses-a ClientHandler, and ClientHandler shouldn't have any knowledge of what an RPCServer is.

Added a global mutex and RPC counter to RPCServer.cpp. Pointers to these then get passed as parameters to ClientHandler::ProcessRPC. The mutex is intialized in ListenForClient.