### PR TITLE
Authent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package( Threads )
 
 add_executable(startClient client/ClientCS.cpp)
 
-add_executable(startServer server/main.cpp server/RPCServer.h server/RPCServer.cpp server/Calculator.h server/Calculator.cpp server/ClientHandler.h server/ClientHandler.cpp)
+add_executable(startServer server/main.cpp server/RPCServer.h server/RPCServer.cpp server/Calculator.h server/Calculator.cpp server/ClientHandler.h server/ClientHandler.cpp server/Authenticator.cpp)
 add_executable(startClientDriver client/ClientTestDriver.cpp)
 target_link_libraries( startServer ${CMAKE_THREAD_LIBS_INIT} )
 target_link_libraries( startClientDriver ${CMAKE_THREAD_LIBS_INIT} )

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,15 @@ startClient : client/ClientCS.cpp
 	$(CXX) $(CXXFLAGS) $< -o startClient
 
 # Link the compiled main and RPCServe code to create the server executable
+# Start with class names
+SERVER_CLASSES = RPCServer Calculator RPCServer ClientHandler Authenticator
 
-startServer : server/main.cpp server/RPCServer.cpp server/Calculator.cpp server/RPCServer.cpp server/ClientHandler.cpp
-	$(CXX) $(CXXFLAGS) $^ -o startServer
+# Create server/*.h
+SERVER_H = $(addsuffix .h, $(addprefix server/, $(SERVER_CLASSES)))
+# create server/*.cpp for classes but NOT main.cpp driver
+SERVER_CPP = $(addsuffix .cpp, $(addprefix server/, $(SERVER_CLASSES)))
+#
+startServer : $(SERVER_H) $(SERVER_CPP) server/main.cpp
+	$(CXX) $(CXXFLAGS) $(SERVER_CPP) server/main.cpp -o startServer
 
-# startServer : server/Calculator.h server/Calculator.cpp  server/main.cpp server/RPCServer.h server/RPCServer.cpp
-#	$(CXX) $(CXXFLAGS) server/Calculator.cpp server/main.cpp server/RPCServer.cpp -o startServer
+

--- a/credentials.csv
+++ b/credentials.csv
@@ -1,0 +1,5 @@
+Mike,Mike
+Troy,HelloWorld!
+Aacer,Pass123!
+Jusmin,12340000
+Chance,passw0rd

--- a/server.puml
+++ b/server.puml
@@ -1,0 +1,91 @@
+@startuml
+class Calculator {
+        + calculateExpression(string inExpr): string
+
+        + binToHex(string &s): string
+        + hexToBin(string &s): string
+        + decToBin(string &s): string
+        + binToDec(string &s): string
+        + convertorMenu(string s, int choice): string
+
+        + mean(vector<float>): float
+        + median(vector<float>): float
+        + var(const vector<float> &vec): float
+        + sd(vector<float>): float
+        + summary(const vector<float> &vec): vector<float>
+        + quantiles(vector<float> data, float quantCuts): vector<float>
+        + percentile(vector<float> vec, float nth): vector<float>
+
+        - expTokenize(string &inExpression): vector<string>
+        - convertToRPN(vector<string> &expTokens): vector<string>
+        - validateInputString(string inExpression, set<char> validChars): bool
+
+        - unordered_map<string, int> precedenceMap
+        - INVALID_EXPRESSION const string = "Invalid expression entered."
+        - INVALID_OPERATOR const string = "Invalid operator entered."
+        - INVALID_ARG const string = "Invalid argument entered."
+}
+
+class ClientHandler {
+        + ClientHandler()
+        + ~ClientHandler()
+        + ProcessRPC(): bool
+
+        - m_socket: int
+        - m_authenticated: bool
+        - m_users: unordered_map<string, string>
+        - CONNECT: const string = "connect"
+        - DISCONNECT: const string = "disconnect"
+        - CALC_EXPR: const string = "calculateExpression"
+        - SUCCESS: const string = "0;"
+        - GENERAL_FAIL: const string = "-1;"
+
+        - ProcessConnectRPC(vector<string> &arrayTokens): bool
+        - ProcessDisconnectRPC(): bool
+        - ProcessCalcExp(vector<std::string>& arrayTokens)
+        - ParseTokens(char* buffer, std::vector<std::string>& a)
+        - HexConversionRPC(vector<std::string> &arrayTokens)
+        - ProcessStatSummary(vector<std::string> &arrayTokens): string
+        - sendBuffer(char *szBuffer) const
+
+}
+
+class RPCServer {
+
+        + lock: GLOBAL pthread_mutex_t
+        + num_rpcs: GLOBAL int = 0
+
+        + RPCServer(const char *serverIP, int port);
+        + ~RPCServer()
+        + StartServer(): bool
+        + ListenForClient(): bool
+
+        - m_rpcCount: int
+        - m_server_fd: int
+        - m_socket: int
+        - m_serverIP: char*
+        - m_port: int
+        - sockaddr_in m_address: struct
+        - m_threadContainer: vector<pthread_t>
+
+        - CONNECT: const string = "connect"
+        - DISCONNECT: const string = "disconnect"
+        - CALC_EXPR: const string = "calculateExpression"
+        - SUCCESS const string = "0;"
+        - GENERAL_FAIL const string = "-1;"
+
+}
+
+Class Authenticator {
+    - m_users: unordered_map<string, string>
+    - readFile(const string &filename, char delim = ','): void
+
+
+}
+
+RPCServer *-- ClientHandler
+ClientHandler *-- Calculator
+
+
+
+@enduml

--- a/server/Authenticator.cpp
+++ b/server/Authenticator.cpp
@@ -6,11 +6,13 @@
 using namespace std;
 
 
+
 Authenticator::Authenticator(const string &fileName)
 {
     // populate username and passwords with data from a file
     readFile(fileName);
 }
+Authenticator::~Authenticator() = default;
 
 bool Authenticator::authenticate(const string &username, const string &password) {
     // First check if the user exists

--- a/server/Authenticator.cpp
+++ b/server/Authenticator.cpp
@@ -1,0 +1,62 @@
+#include "Authenticator.h"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+
+
+Authenticator::Authenticator(const string &fileName)
+{
+    // populate username and passwords with data from a file
+    readFile(fileName);
+}
+
+bool Authenticator::authenticate(const string &username, const string &password) {
+    // First check if the user exists
+    unordered_map<string, string>::const_iterator mapIterator =
+            m_users.find(username);
+    cout << username << "\n" << endl;
+    cout << password << "\n" << endl;
+    cout << m_users[username] << endl;
+    // If the user doesn't exist, return false
+    if (mapIterator == m_users.end())
+        return false;
+
+    // Check that the password matches the record for this username
+    if (m_users[username] == password)
+        return true;
+
+    // Otherwise, return false
+    return false;
+
+
+
+}
+
+void Authenticator::readFile(const string &filename, char delim) {
+
+    // open the file
+    ifstream infile(filename);
+
+    // Make sure the file opened successfully
+    if(infile.is_open()) {
+
+        string line; // This will hold each line of the file
+        while(getline(infile, line)) {
+
+            // Parse each line for username and password
+            string username, password;
+            stringstream strStrm(line);
+
+            // Assume the first two delimited values of the line
+            // are username and password, respectively
+            getline(strStrm, username, delim);
+            getline(strStrm, password, delim);
+
+            // Store extracted username and password in the map attribute
+            m_users[username] = password;
+        }
+    }
+
+}

--- a/server/Authenticator.h
+++ b/server/Authenticator.h
@@ -8,6 +8,7 @@ using namespace std;
 class Authenticator {
 public:
     Authenticator(const string &fileName);
+    ~Authenticator();
 
     bool authenticate(const string &username, const string &password);
 private:

--- a/server/Authenticator.h
+++ b/server/Authenticator.h
@@ -1,0 +1,21 @@
+#ifndef AUTHENTICATOR_H
+#define AUTHENTICATOR_H
+#include <string>
+#include <unordered_map>
+
+using namespace std;
+
+class Authenticator {
+public:
+    Authenticator(const string &fileName);
+
+    bool authenticate(const string &username, const string &password);
+private:
+    unordered_map<string, string> m_users;
+    void readFile(const string &filename, char delim = ',');
+
+
+};
+
+
+#endif //AUTHENTICATOR_H

--- a/server/ClientHandler.cpp
+++ b/server/ClientHandler.cpp
@@ -15,11 +15,11 @@ using namespace std;
 /**
  * Constructor
  */
-ClientHandler::ClientHandler(int socket, string& filename) : m_authenticator(filename)
+ClientHandler::ClientHandler(int socket, const string& filename) : m_authenticator(filename)
 {
     m_socket = socket;
     m_authenticated = false;
-    m_authenticator =  Authenticator(filename);
+    m_authenticator = Authenticator(filename);
 
 }
 /**

--- a/server/ClientHandler.h
+++ b/server/ClientHandler.h
@@ -18,7 +18,7 @@ using namespace std;
 
 class ClientHandler{
 public:
-    ClientHandler(int socket, string &fileName);
+    ClientHandler(int socket, const string &fileName);
     ~ClientHandler();
 
     /**

--- a/server/ClientHandler.h
+++ b/server/ClientHandler.h
@@ -12,12 +12,13 @@
 #include <vector>
 #include "pthread.h"
 #include "GlobalContext.h"
+#include "Authenticator.h"
 
 using namespace std;
 
 class ClientHandler{
 public:
-    ClientHandler(int socket);
+    ClientHandler(int socket, string &fileName);
     ~ClientHandler();
 
     /**
@@ -31,6 +32,8 @@ public:
 private:
     int m_socket; //socket number
     bool m_authenticated; //flag to track if client provided correct credentials and is logged in
+    Authenticator m_authenticator;
+
     unordered_map<string,string> m_users; //map storing all username and
     // password pairs
 

--- a/server/RPCServer.cpp
+++ b/server/RPCServer.cpp
@@ -23,7 +23,7 @@ pthread_mutex_t g_lock;
 
 struct GlobalContext g_globalContext;
 
-string g_credentials = "credentials.csv";
+const static string g_credentials = "credentials.csv";
 
 /**
  * Constructor

--- a/server/RPCServer.cpp
+++ b/server/RPCServer.cpp
@@ -23,7 +23,7 @@ pthread_mutex_t g_lock;
 
 struct GlobalContext g_globalContext;
 
-const string g_credentials = "credentials.csv";
+string g_credentials = "credentials.csv";
 
 /**
  * Constructor

--- a/server/RPCServer.cpp
+++ b/server/RPCServer.cpp
@@ -23,6 +23,8 @@ pthread_mutex_t g_lock;
 
 struct GlobalContext g_globalContext;
 
+const string g_credentials = "credentials.csv";
+
 /**
  * Constructor
  */
@@ -104,7 +106,7 @@ void* startThread(void* input)
     auto socket = *(int*)input;
 
     //Create a new thread handler object
-    ClientHandler* cHandler = new ClientHandler(socket);
+    ClientHandler* cHandler = new ClientHandler(socket, g_credentials);
     //printf ("New thread %lu created with socket: %d\n", pthread_self(), socket);
     cout << "New thread" << pthread_self() << " created with socket: " << socket << endl;
 

--- a/server/credentials.csv
+++ b/server/credentials.csv
@@ -1,0 +1,5 @@
+Mike,Mike
+Troy,HelloWorld!
+Aacer,Pass123!
+Jusmin,12340000
+Chance,passw0rd


### PR DESCRIPTION
Reimplemented authentication. Path to file. is currently a const global variable in RPCServer.cpp, which is passed to ClientHandler instantiation in the startThread function. 

Also, a bit confused about need to change ClientHandler constructor signature to this:
ClientHandler::ClientHandler(int socket, string& filename) : m_authenticator(filename)

Found this solution here, but I'm unclear as to why this is necessary:
https://stackoverflow.com/questions/31488756/explicitly-initialize-member-which-does-not-have-a-default-constructor